### PR TITLE
fix: return proper error by checking quota before

### DIFF
--- a/pkg/api/sign.go
+++ b/pkg/api/sign.go
@@ -56,14 +56,6 @@ func (u User) Sign(artifact Artifact, pubKey string, passphrase string, state me
 		return nil, err
 	}
 
-	synced, err := u.isWalletSynced(pubKey)
-	if err != nil {
-		return nil, err
-	}
-	if !synced {
-		return nil, makeError(fmt.Sprintf(walletNotSyncMsg, artifact.Name), nil)
-	}
-
 	opsLeft, err := u.RemainingSignOps()
 	if err != nil {
 		return nil, err
@@ -71,6 +63,14 @@ func (u User) Sign(artifact Artifact, pubKey string, passphrase string, state me
 
 	if opsLeft < 1 {
 		return nil, fmt.Errorf(errors.NoRemainingSignOps)
+	}
+
+	synced, err := u.isWalletSynced(pubKey)
+	if err != nil {
+		return nil, err
+	}
+	if !synced {
+		return nil, makeError(fmt.Sprintf(walletNotSyncMsg, artifact.Name), nil)
 	}
 
 	return u.commitHash(keyin, passphrase, artifact, state, visibility)


### PR DESCRIPTION
The proper `signature quota exceeded` error was never returned because a non-synced wallet error had occurred before (when quota exceed the `PermissionSyncState` changes from `SYNCED` to `NONE`).

This PR just fixes the checking order to prevent the issue.

