### PR TITLE
feat: untrust unsupport by --hash

### DIFF
--- a/pkg/api/sign.go
+++ b/pkg/api/sign.go
@@ -45,10 +45,10 @@ func (u User) Sign(artifact Artifact, pubKey string, passphrase string, state me
 	}
 
 	if artifact.Hash == "" {
-		return nil, makeError("asset's hash is missing", nil)
+		return nil, makeError("hash is missing", nil)
 	}
-	if artifact.Name == "" {
-		return nil, makeError("asset's name is missing", nil)
+	if artifact.Size < 0 {
+		return nil, makeError("invalid size", nil)
 	}
 
 	keyin, err := u.cfg.OpenKey(pubKey)

--- a/pkg/cmd/sign/flags.go
+++ b/pkg/cmd/sign/flags.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018-2019 vChain, Inc. All Rights Reserved.
+ * This software is released under GPL3.
+ * The full license information can be found under:
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package sign
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func noArgsWhenHash(cmd *cobra.Command, args []string) error {
+	if hash, _ := cmd.Flags().GetString("hash"); hash != "" {
+		if len(args) > 0 {
+			return fmt.Errorf("cannot use arg(s) with --hash")
+		}
+		return nil
+	}
+	return cobra.MinimumNArgs(1)(cmd, args)
+}

--- a/pkg/cmd/sign/unsupport.go
+++ b/pkg/cmd/sign/unsupport.go
@@ -22,5 +22,7 @@ func NewCmdUnsupport() *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runSignWithState(cmd, args, meta.StatusUnsupported)
 	}
+	cmd.Flags().String("hash", "", "specify the hash of an asset signed by you to unsupport, if set no arg(s) can be used")
+	cmd.Args = noArgsWhenHash
 	return cmd
 }

--- a/pkg/cmd/sign/untrust.go
+++ b/pkg/cmd/sign/untrust.go
@@ -22,5 +22,7 @@ func NewCmdUntrust() *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runSignWithState(cmd, args, meta.StatusUntrusted)
 	}
+	cmd.Flags().String("hash", "", "specify the hash of an asset signed by you to untrust, if set no arg(s) can be used")
+	cmd.Args = noArgsWhenHash
 	return cmd
 }


### PR DESCRIPTION
An user might want to untrust or unsupport an asset he/she doesn’t have anymore.
This PR adds the ability to _untrust_ or _unsupport_ user's own assets by using `--hash` flag.

It also includes minor fixes and additions to `pkg/api`

