### PR TITLE
fix: added ability to do not write on read only dir (fixes #45)

### DIFF
--- a/pkg/cmd/sign/hook.go
+++ b/pkg/cmd/sign/hook.go
@@ -35,7 +35,8 @@ func (h *hook) finalize(v *api.BlockchainVerification) error {
 	if h != nil && !v.Unknown() {
 		manifest, path := dir.Metadata(h.a)
 		if manifest != nil && path != "" {
-			return bundle.WriteManifest(*manifest, filepath.Join(path, bundle.ManifestFilename))
+			// manifest is optional, we can ignore errors
+			bundle.WriteManifest(*manifest, filepath.Join(path, bundle.ManifestFilename))
 		}
 	}
 	return nil

--- a/pkg/cmd/sign/sign.go
+++ b/pkg/cmd/sign/sign.go
@@ -76,6 +76,7 @@ Assets are referenced by passed ARG with notarization only accepting
 	cmd.Flags().StringP("name", "n", "", "set the asset name")
 	cmd.Flags().BoolP("public", "p", false, "when notarized as public, the asset name and metadata will be visible to everyone")
 	cmd.Flags().String("hash", "", "specify the hash instead of using an asset, if set no ARG(s) can be used")
+	cmd.Flags().Bool("no-ignore-file", false, "if set, .vcnignore will be not written inside the targeted dir")
 	cmd.SetUsageTemplate(
 		strings.Replace(cmd.UsageTemplate(), "{{.UseLine}}", "{{.UseLine}} ARG", 1),
 	)
@@ -86,8 +87,14 @@ Assets are referenced by passed ARG with notarization only accepting
 func runSignWithState(cmd *cobra.Command, args []string, state meta.Status) error {
 
 	// default extractors options
-	extractorOptions := []extractor.Option{
-		dir.WithIgnoreFileInit(),
+	extractorOptions := []extractor.Option{}
+
+	noIgnoreFile, err := cmd.Flags().GetBool("no-ignore-file")
+	if err != nil {
+		return err
+	}
+	if !noIgnoreFile {
+		extractorOptions = append(extractorOptions, dir.WithIgnoreFileInit())
 	}
 
 	var hash string


### PR DESCRIPTION
This PR introduces an option flag `--no-ignore-file` for the notarization command in order to instruct vcn to do not store `.vcnignore` file. Also, any error regarding the `.vcn.manifest.json` is ignored (because it's optional, we can safely skip it).

Both fixes aim to solve the issue #45 related to read only dir.
cc @ivan-w

PS: maybe we need a better name and help message for the flag