### PR TITLE
fix: Pull latest xgo (go cross compilation tools) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ build/xgo:
 	$(DOCKER) build \
 			-f ./build/xgo/Dockerfile \
 			-t vcn-xgo \
+			--pull=true \
 			./build/xgo
 
 .PHONY: build/makensis


### PR DESCRIPTION
When creating the full stack (with cross compilation), via 'make dist' ensure we have the latest techknowlogick/xgo version. This will only pull the image if it is not up to date in the cache.