### PR TITLE
chore: add a separated CNLC jumpstart

### DIFF
--- a/BUILD-smart-contracts.md
+++ b/BUILD-smart-contracts.md
@@ -1,0 +1,23 @@
+## Generating smart contracts on linux
+
+Clone https://github.com/ethereum/go-ethereum and compile `abigen` command in ./cmd/abigen
+
+Download solc at https://github.com/ethereum/solidity/releases?after=v-1.5.0 and chmod +x on it and copy in /usr/bin
+solc version must be:
+```bash
+solc --version
+solc, the solidity compiler commandline interface
+Version: -1.4.24+commit.e67f0147.Linux.g++
+```
+
+Place at the root of the contracts repo and generate go files with:
+```
+abigen --sol organisations/contracts/OrganisationsRelay.sol --pkg blockchain --out organisationsrelay.go
+abigen --sol assets/contracts/AssetsRelay.sol --pkg blockchain --out assetsrelay.go
+```
+
+## Cross-compiling for various platforms
+
+The C libraries of [go-ethereum](https://github.com/ethereum/go-ethereum) make a more sophisticated cross-compilation
+necessary.
+The `make dist` target takes care of all steps by using [xgo](https://github.com/techknowlogick/xgo) and [docker](https://github.com/docker).

--- a/README.md
+++ b/README.md
@@ -134,13 +134,15 @@ Basically, `vcn` can notarize or authenticate any of the following kind of asset
 
 > It's possible to provide a hash value directly by using the `--hash` flag.
 
-> It's also possible to notarize assets using wildcard.
-> With `--recursive` flag is possible to iterate over inner directories.
->```shell script
->./vcn n "*.md" --recursive
->```
-
 For detailed **command line usage** see [docs/cmd/vcn.md](https://github.com/vchain-us/vcn/blob/master/docs/cmd/vcn.md) or just run `vcn help`.
+
+### Wildcard support and recursive notarization
+
+ It's also possible to notarize assets using wildcard.
+ With `--recursive` flag is possible to iterate over inner directories.
+```shell script
+./vcn n "*.md" --recursive
+```
 
 ### Local API server
 

--- a/vcn-cnlc-jumpstart.md
+++ b/vcn-cnlc-jumpstart.md
@@ -1,37 +1,24 @@
-# vcn  <img align="right" src="https://github.com/vchain-us/vcn/blob/master/docs/img/cn-color.eeadbabe.svg" width="160px"/>
-> **_vChain CodeNotary_**
-
-[![CircleCI](https://circleci.com/gh/vchain-us/vcn.svg?style=shield)](https://circleci.com/gh/vchain-us/vcn)
-[![Go Report Card](https://goreportcard.com/badge/github.com/vchain-us/vcn?style=flat-square)](https://goreportcard.com/report/github.com/vchain-us/vcn)
-[![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/vchain-us/vcn)
-[![Docker pulls](https://img.shields.io/docker/pulls/codenotary/vcn?style=flat-square)](https://hub.docker.com/r/codenotary/vcn)
-[![Changelog](https://img.shields.io/badge/CHANGELOG-.md-blue?style=flat-square)](https://github.com/vchain-us/vcn/blob/master/CHANGELOG.md)
-[![Release](https://img.shields.io/github/release/vchain-us/vcn.svg?style=flat-square)](https://github.com/vchain-us/vcn/releases/latest)
-## The Trust and Integrity platform for the Cloud native environment
-Give any digital asset a meaningful, globally-unique, immutable identity that is authentic, verifiable, traceable from anywhere.
-
-<img align="right" src="https://github.com/vchain-us/vcn/blob/master/docs/img/codenotary_mascot.png" width="256px"/>
-When using CodeNotary vcn in source code, release, deployment or at runtime, you allow a continuous trust verification that can be used to detect unusual or unwanted activity in your workload and act on it.
-<br/>
-Powered by CodeNotary's digital identity infrastructure, vcn lets you notarize all of your digital assets that add a trust level of your choice, custom attributes and a meaningful status without touching or appending anything (unlike digital certificates).
-That allows change and revocation post-release without breaking any customer environment.
-<br/>
-Everything is done in a global, collaborative way to break the common silo solution architecture. Leveraging an immutable, always-on DLT platform allows you to avoid complex setup of Certificate authorities or digital certificates (that are unfit for DevOps anyway).
+# vcn - CodeNotary Ledger Compliance jumpstart  <img align="right" src="https://github.com/vchain-us/vcn/blob/master/docs/img/cn-color.eeadbabe.svg" width="160px"/>
 
 ## Table of contents
 
+- [CodeNotary Ledger Compliance](#codenotary-ledger-compliance)
 - [Quick start](#quick-start)
-- [DevSecOps in mind](#devsecops-in-mind)
-- [What kind of behaviors can CodeNotary vcn detect](#what-kind-of-behaviors-can-codenotary-vcn-detect)
-- [How it works](#how-it-works)
 - [Installation](#installation)
 - [Usage](#usage)
-- [Integrations](#integrations)
 - [Documentation](#documentation)
-- [Testing](#testing)
-- [CodeNotary Ledger Compliance](#codenotary-ledger-compliance)
 
-- [License](#license)
+## CodeNotary Ledger Compliance
+
+vcn has been extended in order to be compatible with [CodeNotary Ledger Compliance](https://codenotary.com/) .
+Notarized assets informations are stored in a tamperproof ledger with cryptographic verification backed by [immudb](https://codenotary.com/technologies/immudb/), the immutable database.
+Thanks to this `vcn` is faster and provides more powerful functionalities like local data inclusion, consistency verification and enhanced CLI filters.
+
+### Obtain an API Key
+To provide access to Ledger Compliance a valid API Key is required.
+This API Key is bound to a specific Ledger and it's required during vcn login.
+To obtain a valid key you need to get access to a licensed CodeNotary Ledger Compliance installation.
+
 
 ## Quick start
 
@@ -46,53 +33,64 @@ Everything is done in a global, collaborative way to break the common silo solut
 2. **Authenticate digital objects** You can use the command as a starting point.
 
    ```bash
+   vcn login --lc-host cnlc-host.com --lc-port 443
    vcn authenticate <file|dir://directory|docker://dockerimage|git://gitdirectory>
    ```
 
-3. [**Create your identity (free)**](https://dashboard.codenotary.io/auth/signup) You need an identity at CodeNotary to notarize objects yourself (btw, we're a data-minimum company and only ask for data that is really required)
 
-
-4. **Notarize existing digital objects** Once you have an account you can start notarizing digital assets to give them an identity.
+3. **Notarize existing digital objects** Once you have an account you can start notarizing digital assets to give them an identity.
 
    ```bash
-   vcn login
+   # vcn login can be skipped, if already performed
+   vcn login --lc-host cnlc-host.com --lc-port 443
    vcn notarize <file|dir://directory|docker://dockerimage|git://gitdirectory>
    ```
 
+### Login
 
-## DevSecOps in mind
-Codenotary vcn is a solution written by a devops-obsessed engineers for Devops engineers to bring better trust and security to the the CloudNative source to deployment process
+To login in Ledger Compliance provides `--lc-port` and `--lc-host` flag, also the user submit API Key when requested.
+Once host, port and API Key are provided, it's possible to omit them in following commands. Otherwise, the user can provide them in other commands like `notarize`, `verify` or `inspect`.
 
-## What kind of behaviors can CodeNotary vcn detect
-vcn (and its extensions for Docker, Kubernetes, documents or CI/CD) can detect, authenticate and alert on any behavior that involves using unauthentic digital assets. vcn verification can be embedded anywhere and can be used to trigger alerts, updates or workflows.
+```shell script
+vcn login --lc-port 443 --lc-host cnlc-host.com
+```
 
-vcn is so versatile, it can help detecting or acting on the following (but not limited to):
-* Immutable tagging of source code, builds, and container images with version number, owner, timestamp, organization, trust level, and much more
-* Simple and tamper-proof extraction of notarized tags like version number, owner, timestamp, organization, and trust level from any source code, build and container (based on the related image)
-* Quickly discover and identify untrusted, revoked or obsolete libraries, builds, and containers in your application
-* Detect the launch of an authorized or unknown container immediately
-* Prevent untrusted or revoked containers from starting in production
-* Verify the integrity and the publisher of all the data received over any channel
+> One time password (otp) is not mandatory
 
-and more
-* Enable application version checks and actions
-* Buggy or rogue libraries can be traced by simple revoke or unsupport
-* Revoke or unsupport your build or build version post-deployment (no complex certificate revocation that includes delivery of newly signed builds)
-* Stop unwanted containers from being launched
-* Make revocation part of the remediation process
-* Use revocation without impairing customer environments
-* Trace source code to build to deployment by integration into CI/CD or manual workflow
-* Tag your applications for specific use cases (alpha, beta - non-commercial aso).
+Alternatively, for using vcn in non-interactive mode, the user can supply the API Key via the `VCN_LC_API_KEY` environment variable, e.g.:
 
-not just containers, also virtual machines -  [check out vCenter Connector, in case you're running VMware vSphere](https://github.com/openfaas-incubator/vcenter-connector)
-* Newly created or existing virtual machines automatically get a unique identity that can be trusted or untrusted
-* Prevent launch of untrusted VMs
-* Stop or suspend running outdated or untrusted VMs
-* Detect the cloning or export of VMs and alert
+```shell script
+export VCN_LC_API_KEY=apikeyhere
 
+# No vcn login command needed
 
-## How it works
-![vcn How it works](https://raw.githubusercontent.com/vchain-us/vcn/master/docs/vcn_hiwb.png "How it works")
+# Other vcn commands...
+vcn notarize asset.txt --lc-host cnlc-host.com --lc-port 443
+```
+
+#### TLS
+
+By default, vcn will try to establish a secure connection (TLS) with a Ledger Compliance server.
+
+The user can also provide a custom TLS certificate for the server, in case vcn is not able to download it automatically:
+
+```shell script
+vcn login --lc-port 443 --lc-host cnlc-host.com --lc-cert mycert.pem
+```
+
+For testing purposes or in case the provided certificate should be always trusted by the client, the user can
+configure vcn to skip TLS certificate verification with the `--lc-skip-tls-verify` option:
+
+```shell script
+vcn login --lc-port 443 --lc-host cnlc-host.com --lc-cert mycert.pem --lc-skip-tls-verify
+```
+
+Finally in case the Ledger Compliance Server is not exposed through a TLS endpoint, the user can request a cleartext
+connection using the `--lc-no-tls` option:
+
+```shell script
+vcn login --lc-port 80 --lc-host cnlc-host.com --lc-no-tls
+```
 
 ## Installation
 
@@ -132,13 +130,13 @@ Basically, `vcn` can notarize or authenticate any of the following kind of asset
 - a **git commit** (by prefixing the local git working directory path with `git://`)
 - a **container image** (by using `docker://` or `podman://` followed by the name of an image present in the local registry of docker or podman, respectively)
 
-> It's possible to provide a hash value directly by using the `--hash` flag.
+It's possible to provide a hash value directly by using the `--hash` flag.
+It's also possible to notarize assets using a wildcard pattern.
 
-> It's also possible to notarize assets using wildcard.
-> With `--recursive` flag is possible to iterate over inner directories.
->```shell script
->./vcn n "*.md" --recursive
->```
+With `--recursive` flag the utility can recursively notarize inner directories.
+```shell script
+./vcn n "*.md" --recursive
+```
 
 For detailed **command line usage** see [docs/cmd/vcn.md](https://github.com/vchain-us/vcn/blob/master/docs/cmd/vcn.md) or just run `vcn help`.
 
@@ -146,7 +144,8 @@ For detailed **command line usage** see [docs/cmd/vcn.md](https://github.com/vch
 
 It's possible to start a local API server. All commands are supported.
 The notarization password can be submitted with the `x-notarization-password` header.
-Examples:
+
+Example:
 
 ```bash
 curl --location --request GET '127.0.0.1:8080/inspect/e2b58ab102dbadb3b1fd5139c8d2a937dc622b1b0d0907075edea163fe2cd093' \
@@ -161,13 +160,13 @@ curl --location --request GET '127.0.0.1:8080/inspect/e2b58ab102dbadb3b1fd5139c8
 	"ContentType":	"text/plain; charset=utf-8"
 }'
 ```
+
 ### Notarization
 
-Register an account with [codernotary.io](https://codenotary.io) first.
+Start with the `login` command. `vcn` will walk you through login and importing up your secret upon initial use.
 
-Then start with the `login` command. `vcn` will walk you through login and importing up your secret upon initial use.
 ```
-vcn login
+vcn login --lc-host cnlc-host.com --lc-port 443
 ```
 
 Once your secret is set you can notarize assets like in the following examples:
@@ -210,7 +209,6 @@ vcn authenticate podman://<imageId>
 vcn authenticate git://<path_to_git_repo>
 vcn authenticate --hash <hash>
 ```
-> You can use `vcn authenticate` even without a [codernotary.io](https://codenotary.io) account.
 
 To output results in `json` or `yaml` formats:
 ```
@@ -218,18 +216,6 @@ vcn authenticate --output=json <asset>
 vcn authenticate --output=yaml <asset>
 ```
 > Check out the [user guide](https://github.com/vchain-us/vcn/blob/master/docs/user-guide/formatted-output.md) for further details.
-
-
-## Integrations
-
-* [Github Action](https://github.com/marketplace/actions/verify-commit) - An action to verify the authenticity of your commits within your Github workflow
-* [docker](https://github.com/vchain-us/vcn/blob/master/docs/user-guide/schemes/docker.md) - Out of the box support for notarizing and authenticating Docker images.
-* [hub.docker.com/r/codenotary/vcn](https://hub.docker.com/r/codenotary/vcn) - The `vcn`'s DockerHub repository.
-* [kube-notary](https://github.com/vchain-us/kube-notary) - A Kubernetes watchdog for verifying image trust with CodeNotary.
-* [vcn-watchdog](https://github.com/vchain-us/vcn-watchdog) - Continuous authentication with CodeNotary for Docker.
-* [jsvcn](https://github.com/vchain-us/jsvcn) - CodeNotary JavaScript Client.
-* [jvcn](https://github.com/vchain-us/jvcn) - CodeNotary Java Bindings.
-* [jvcn-maven-plugin](https://github.com/vchain-us/jvcn-maven-plugin) - Maven dependency authentication and enforcement.
 
 ## Documentation
 
@@ -295,7 +281,7 @@ vcn authenticate --hash fce289e99eb9bca977dae136fbe2a82b6b7d4c372474c9235adc1741
 
 In case you want to unsupport/untrust an asset of yours that you no longer have, you can do so using the asset hash(es) with the following steps below.
 
-First, you’ll need to get the hash of the asset from your CodeNotary [dashboard](https://dashboard.codenotary.io/) or alternatively you can use the `vcn list` command. Then, in the CLI, use:
+First, you’ll need to get the hash of the asset from your CodeNotary Ledger Compliance dashboard or alternatively you can use the `vcn list` command. Then, in the CLI, use:
 
 ```
 vcn untrust --hash <asset's hash>
@@ -307,89 +293,22 @@ vcn unsupport --hash <asset's hash>
 
 First, you’ll need to make `vcn` have access to the `${HOME}/.vcn` folder that holds your secret (the private key).
 Then, set up your environment accordingly using the following commands:
+
+```bash
+export VCN_LC_API_KEY=apikeyhere
 ```
-export VCN_USER=<email>
-export VCN_PASSWORD=<login password>
-export VCN_NOTARIZATION_PASSWORD=<notarization password>
-```
-> It's possible to disable one time password requirement with:
->```bash
-> export VCN_OTP_EMPTY=true
-> ```
+
 Once done, you can use `vcn` in your non-interactive environment using:
 
 ```
-vcn login
+vcn login --lc-host cnlc-host.com --lc-port 443
 vcn notarize <asset>
 ```
+
 > Other commands like `untrust` and `unsupport` will also work.
 
-## Testing
-```
-make test
-```
 
-## CodeNotary Ledger Compliance
-
-Vcn was extended in order to be compatible with [CodeNotary Ledger Compliance](https://codenotary.com/) .
-Notarized assets informations are stored in a tamperproof ledger with cryptographic verification backed by [immudb](https://codenotary.com/technologies/immudb/), the immutable database.
-Thanks to this `vcn` is faster and provides more powerful functionalities like local data inclusion, consistency verification and enhanced CLI filters.
-
-### Obtain an API Key
-To provide access to Ledger Compliance a valid API Key is required.
-This API Key is bound to a specific Ledger and it's required during vcn login.
-To obtain a valid key you need to get access to a licensed CodeNotary Ledger Compliance installation.
-
-### Login
-
-To login in Ledger Compliance provides `--lc-port` and `--lc-host` flag, also the user submit API Key when requested.
-Once host, port and API Key are provided, it's possible to omit them in following commands. Otherwise, the user can provide them in other commands like `notarize`, `verify` or `inspect`.
-
-```shell script
-vcn login --lc-port 443 --lc-host cnlc-host.com
-```
-
-> One time password (otp) is not mandatory
-
-Alternatively, for using vcn in non-interactive mode, the user can supply the API Key via the `VCN_LC_API_KEY` environment variable, e.g.:
-
-```shell script
-export VCN_LC_API_KEY=apikeyhere
-
-# No vcn login command needed
-
-# Other vcn commands...
-vcn notarize asset.txt --lc-host cnlc-host.com --lc-port 443
-```
-
-#### TLS
-
-By default, vcn will try to establish a secure connection (TLS) with a Ledger Compliance server.
-
-The user can also provide a custom TLS certificate for the server, in case vcn is not able to download it automatically:
-
-```shell script
-vcn login --lc-port 443 --lc-host cnlc-host.com --lc-cert mycert.pem
-```
-
-For testing purposes or in case the provided certificate should be always trusted by the client, the user can
-configure vcn to skip TLS certificate verification with the `--lc-skip-tls-verify` option:
-
-```shell script
-vcn login --lc-port 443 --lc-host cnlc-host.com --lc-cert mycert.pem --lc-skip-tls-verify
-```
-
-Finally in case the Ledger Compliance Server is not exposed through a TLS endpoint, the user can request a cleartext
-connection using the `--lc-no-tls` option:
-
-```shell script
-vcn login --lc-port 80 --lc-host cnlc-host.com --lc-no-tls
-```
-
-### Commands
-All commands reference didn't change.
-
-### Add custom metadata when signing assets
+#### Add custom metadata when signing assets
 The user can upload custom metadata when doing an asset notarization using the `--attr` option, e.g.:
 
 ```shell script
@@ -404,7 +323,7 @@ The user can read the metadata back on asset authentication, i.e. using the `jq`
 vcn a README.md -o json | jq .metadata
 ```
 
-### Inspect
+#### Inspect
 Inspect has been extended with the addition of new filter: `--last`, `--first`, `--start` and `--end`.
 With `--last` and `--first` are returned the N first or last respectively.
 
@@ -420,7 +339,7 @@ vcn inspect document.pdf --start 2020/10/28-08:00:00 --end 2020/10/28-17:00:00
 
 If no filters are provided only maximum 100 items are returned.
 
-### Signer Identifier
+#### Signer Identifier
 It's possible to filter results by signer identifier:
 
 ```shell script
@@ -473,7 +392,3 @@ curl --location --request POST '127.0.0.1:8081/untrust' \
 	"ContentType":	"text/plain; charset=utf-8"
 }'
 ```
-
-## License
-
-This software is released under [GPL3](https://www.gnu.org/licenses/gpl-3.0.en.html).

--- a/vcn-cnlc-jumpstart.md
+++ b/vcn-cnlc-jumpstart.md
@@ -131,14 +131,17 @@ Basically, `vcn` can notarize or authenticate any of the following kind of asset
 - a **container image** (by using `docker://` or `podman://` followed by the name of an image present in the local registry of docker or podman, respectively)
 
 It's possible to provide a hash value directly by using the `--hash` flag.
+
+For detailed **command line usage** see [docs/cmd/vcn.md](https://github.com/vchain-us/vcn/blob/master/docs/cmd/vcn.md) or just run `vcn help`.
+
+### Wildcard support and recursive notarization
+
 It's also possible to notarize assets using a wildcard pattern.
 
 With `--recursive` flag the utility can recursively notarize inner directories.
 ```shell script
 ./vcn n "*.md" --recursive
 ```
-
-For detailed **command line usage** see [docs/cmd/vcn.md](https://github.com/vchain-us/vcn/blob/master/docs/cmd/vcn.md) or just run `vcn help`.
 
 ### Local API server
 

--- a/vcn-cnlc-jumpstart.md
+++ b/vcn-cnlc-jumpstart.md
@@ -261,17 +261,6 @@ By adding `--signerID`, you can authenticate that your asset has been signed by 
 vcn authenticate --signerID 0x8f2d1422aed72df1dba90cf9a924f2f3eb3ccd87 docker://hello-world
 ```
 
-#### Authenticate by a list of signers
-
-If an asset you or your organization wants to trust needs to be verified against a list of signers as a prerequisite, then use the `vcn authenticate` command and the following syntax:
-
-- Add a `--signerID` flag in front of each SignerID you want to add
-(eg. `--signerID 0x0...1 --signerID 0x0...2`)
-- Or set the env var `VCN_SIGNERID` correctly by using a space to separate each SignerID (eg. `VCN_SIGNERID=0x0...1 0x0...2`)
-> Be aware that using the `--signerID` flag will take precedence over `VCN_SIGNERID`.
-
-The asset authentication will succeed only if the asset has been signed by at least one of the signers.
-
 #### Authenticate using the asset's hash
 
 If you want to authenticate an asset using only its hash, you can do so by using the command as shown below:


### PR DESCRIPTION
- Put smart contracts build instructions in a separate MD file
- Updated vcn README with CNLC TLS options, asset metadata and API key support for non-interactive mode
- Extracted a separated CNLC jumpstart file from the README